### PR TITLE
Use relative path to form validation module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Each release is divided into the following main categories:
 - NEW: New features or plugins
 - FIXES: General bugfixes
 
+## v2.7.2
+### FIXES
+- Used relative path to form validation module [#107](https://github.com/allink/allink-core-static/pull/107)
+
+
 ## v2.7.1
 ### FIXES
 - Fixed accordion transitions [#99](https://github.com/allink/allink-core-static/pull/99)

--- a/js/modules/ajax-load-plugins.js
+++ b/js/modules/ajax-load-plugins.js
@@ -1,4 +1,4 @@
-import {initFormValidation} from "allink-core-static/js/modules/form-validation";
+import {initFormValidation} from './form-validation';
 
 $(function () {
 


### PR DESCRIPTION
Prevent error when symlinking allink-core-static for local development.