### PR TITLE
Remove pseudo default values for fluid-size and spacings-size mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Each release is divided into the following main categories:
 - Fixed radio / checkbox spacing [#105](https://github.com/allink/allink-core-static/pull/105)
 - Fixed gallery transition styles and added keyboard controls [#115](https://github.com/allink/allink-core-static/pull/115)
 - Added color transition for link icons [#121](https://github.com/allink/allink-core-static/pull/121)
+- Removed pseudo default values for fluid-size and spacings-size mixins [#122](https://github.com/allink/allink-core-static/pull/122)
 
 
 ## v2.7.2

--- a/scss/mixins/_global.scss
+++ b/scss/mixins/_global.scss
@@ -88,7 +88,7 @@ Print: Add print styles on the spot. Easier than to navigate back and forth
 
 // Fluid sizes mixin for spacings, font-sizes, widths, heights, etc.
 // It can either have a name (i.e. 'y-section-1') or a map (i.e. (min: 1rem, max: 5rem) given. In-between in gets calculated fluidly.
-@mixin fluid-size($size, $property: null, $sizings-map: (), $fluid-breakpoints: $fluid-breakpoints, $negative: false) {
+@mixin fluid-size($size, $property, $sizings-map: (), $fluid-breakpoints: $fluid-breakpoints, $negative: false) {
     $min-breakpoint: to-rem(map-get($fluid-breakpoints, 'min'));
     $max-breakpoint: to-rem(map-get($fluid-breakpoints, 'max'));
 

--- a/scss/mixins/_spacings.scss
+++ b/scss/mixins/_spacings.scss
@@ -131,7 +131,7 @@ Each spacing must have a min (below 320px) and a max size (above 1760px). In-bet
 
 */
 
-@mixin spacings-size($spacings-size, $property: null, $spacings-map: $spacings-sizes, $spacings-breakpoints: $fluid-breakpoints, $negative: false) {
+@mixin spacings-size($spacings-size, $property, $spacings-map: $spacings-sizes, $spacings-breakpoints: $fluid-breakpoints, $negative: false) {
     @include fluid-size($spacings-size, $property, $spacings-map, $spacings-breakpoints, $negative);
 }
 


### PR DESCRIPTION
This will trigger the correct error message if the $property parameter is missing.