### PR TITLE
Use default cursor behavior on softpage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Each release is divided into the following main categories:
 - Added lazyload-fade animation [#120](https://github.com/allink/allink-core-static/pull/120)
 - Updated get chrome translation [#123](https://github.com/allink/allink-core-static/pull/123)
 - Added hover styles and display block for form controls [#125](https://github.com/allink/allink-core-static/pull/125)
+- Used default cursor behavior on softpage [#128](https://github.com/allink/allink-core-static/pull/128)
 
 ### FIXES
 - Fixed radio / checkbox spacing [#105](https://github.com/allink/allink-core-static/pull/105)

--- a/scss/modals/_softpage.scss
+++ b/scss/modals/_softpage.scss
@@ -9,6 +9,7 @@ Softpage
     visibility: visible;
     transform: translate(0, $softpage-content-offset);
     transition: $softpage-content-transition;
+    cursor: auto;
 
     .tingle-modal-box {
         margin: 0;


### PR DESCRIPTION
The tingle modal is using cursor: pointer which caused a weird cursor behavior on softpage headers.