### PR TITLE
Enable subtext for bootstrap select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Each release is divided into the following main categories:
 - Added cookie message [#138](https://github.com/allink/allink-core-static/pull/138), [#140](https://github.com/allink/allink-core-static/pull/140), [#141](https://github.com/allink/allink-core-static/pull/141), [#142](https://github.com/allink/allink-core-static/pull/142)
 - Added breakpoint variable for quote plugin with default value [#137](https://github.com/allink/allink-core-static/pull/137)
 - Removed selection on images [#144](https://github.com/allink/allink-core-static/pull/144)
+- Enabled subtext for bootstrap select [#147](https://github.com/allink/allink-core-static/pull/147)
 
 ### FIXES
 - Fixed radio / checkbox spacing [#105](https://github.com/allink/allink-core-static/pull/105)

--- a/js/modules/bootstrap-select.js
+++ b/js/modules/bootstrap-select.js
@@ -23,6 +23,7 @@ $(function(){
                     size: 'auto',
                     dropupAuto: true, // per default, let bootstrap select choose where to dislpay the dropdown (above or below). Should you want to force to display the form below, add the `data-dropup-auto="false"` attribute to the desired <select> element.
                     windowPadding: [bs_select_offset_top,0,0,0],
+                    showSubtext: true
                 });
                 // mark as initialized
                 $select.addClass(initialized_class);


### PR DESCRIPTION
The subtext label will only be shown if it's added in the markup. This has never been the case in any previous projects.